### PR TITLE
Update hyprland.conf blur variables to match new decoration layout

### DIFF
--- a/HyprV/hypr/hyprland.conf
+++ b/HyprV/hypr/hyprland.conf
@@ -62,10 +62,12 @@ decoration {
     # See https://wiki.hyprland.org/Configuring/Variables/ for more
 
     rounding = 5
-    blur = yes
-    blur_size = 7
-    blur_passes = 4
-    blur_new_optimizations = on
+    blur {
+        enabled = true
+        size = 7
+        passes = 4
+        new_optimizations = on
+    }
 
     blurls = lockscreen
 


### PR DESCRIPTION
The newest update to the Hyprland variables sees the blur variables moved into their own "blur" sub-category: https://wiki.hyprland.org/Configuring/Variables/#decoration

This PR updates the existing hyprland.conf file to move the associated blur variables into this sub-category